### PR TITLE
Add simple Flask web UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,42 +1,52 @@
-# Zillow Clone Scraper and Form Auto-Filler
+# Zillow Clone Scraper and Web UI
 
-This Python script scrapes apartment listings from a Zillow clone site and automatically submits the address, price, and link of each listing into a Google Form. The responses are stored in a connected Google Spreadsheet for easy tracking.
+This project scrapes apartment listings from a Zillow clone site and can optionally submit the address, price, and link of each listing into a Google Form. A simple Flask UI is included to easily display the scraped listings in a table for presentation purposes.
 
 ## Features
 
 - Scrapes addresses, prices, and links from listings
 - Submits each listing to a Google Form
-- Data is saved into a linked Google Sheet
+- Web interface for viewing scraped listings
+- Data is saved into a linked Google Sheet when using the auto‑filler
 - Browser closes automatically when done
 
 ## Requirements
 
 - Python 3.10 or higher
-- Chrome and ChromeDriver installed
+- Chrome and ChromeDriver installed for the form auto‑filler
 
 ### Python packages
 
 Install dependencies with:
 
-```
+```bash
 pip install -r requirements.txt
 ```
 
 **requirements.txt:**
-```
+```text
 selenium
 beautifulsoup4
 requests
 python-dotenv
+Flask
 ```
 
 ## How to Use
 
 1. Clone the repository
-2. Update the `FORM_URL` and verify the XPaths match your Google Form
-3. Run the script:
+2. Update the `FORM_URL` and verify the XPaths match your Google Form if you wish to auto‑submit listings
+3. Run the web interface:
 
+```bash
+python app.py
 ```
+
+Visit `http://127.0.0.1:5000` in your browser to view the listings.
+
+Alternatively, run the command‑line script to automatically fill the form:
+
+```bash
 python main.py
 ```
 

--- a/app.py
+++ b/app.py
@@ -1,0 +1,52 @@
+from flask import Flask, render_template
+import requests
+from bs4 import BeautifulSoup
+
+CLONE_URL = "https://appbrewery.github.io/Zillow-Clone/"
+
+app = Flask(__name__)
+
+HEADER = {
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
+    "Accept-Encoding": "gzip, deflate, br, zstd",
+    "Accept-Language": "en-GB,de;q=0.8,fr;q=0.6,en;q=0.4,ja;q=0.2",
+    "Dnt": "1",
+    "Priority": "u=1",
+    "Sec-Fetch-Dest": "document",
+    "Sec-Fetch-Mode": "navigate",
+    "Sec-Fetch-Site": "none",
+    "Sec-Fetch-User": "?1",
+    "Sec-Gpc": "1",
+    "Upgrade-Insecure-Requests": "1",
+    "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:126.0) Gecko/20100101 Firefox/126.0",
+}
+
+
+def scrape_listings():
+    response = requests.get(url=CLONE_URL, headers=HEADER)
+    soup = BeautifulSoup(response.text, "html.parser")
+
+    address_elements = soup.find_all('address', {"data-test": "property-card-addr"})
+    addresses = [addr.get_text(strip=True).replace("|", "") for addr in address_elements]
+
+    price_elements = soup.find_all('span', class_="PropertyCardWrapper__StyledPriceLine")
+    prices = [
+        price.get_text(strip=True).replace("+/mo", "").replace("/mo", "").replace("+ 1 bd", "").replace("+ 1bd", "")
+        for price in price_elements
+    ]
+
+    address_links = soup.find_all('a', {"data-test": "property-card-link"})
+    links = [link["href"] for link in address_links]
+
+    listings = [dict(address=a, price=p, link=l) for a, p, l in zip(addresses, prices, links)]
+    return listings
+
+
+@app.route('/')
+def index():
+    listings = scrape_listings()
+    return render_template('index.html', listings=listings)
+
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ selenium
 beautifulsoup4
 requests
 python-dotenv
+
+Flask

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,45 @@
+body {
+    font-family: Arial, sans-serif;
+    background-color: #f4f4f4;
+    margin: 0;
+    padding: 20px;
+}
+
+.container {
+    max-width: 900px;
+    margin: auto;
+    background: white;
+    padding: 20px;
+    border-radius: 8px;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+h1 {
+    text-align: center;
+    color: #333;
+}
+
+table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 20px;
+}
+
+thead {
+    background-color: #007BFF;
+    color: white;
+}
+
+td, th {
+    padding: 12px;
+    border-bottom: 1px solid #ddd;
+}
+
+a {
+    color: #007BFF;
+    text-decoration: none;
+}
+
+a:hover {
+    text-decoration: underline;
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Zillow Listings</title>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.1/normalize.min.css">
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+    <div class="container">
+        <h1>Zillow Clone Listings</h1>
+        <table>
+            <thead>
+                <tr>
+                    <th>Address</th>
+                    <th>Price</th>
+                    <th>Link</th>
+                </tr>
+            </thead>
+            <tbody>
+            {% for listing in listings %}
+                <tr>
+                    <td>{{ listing.address }}</td>
+                    <td>{{ listing.price }}</td>
+                    <td><a href="{{ listing.link }}" target="_blank">View</a></td>
+                </tr>
+            {% endfor %}
+            </tbody>
+        </table>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a Flask web interface that displays listings scraped from the Zillow clone
- style the page with basic CSS
- include an HTML template
- document the new UI usage
- update dependencies with Flask

## Testing
- `python -m pip install -r requirements.txt`
- `python app.py` *(ran briefly to ensure server starts)*


------
https://chatgpt.com/codex/tasks/task_e_6859aacfd34883268f8df6929cec156f