### PR TITLE
Fix listing prices and UI

### DIFF
--- a/app.py
+++ b/app.py
@@ -42,7 +42,14 @@ def scrape_listings():
         )
         for item in results:
             address = item.get("address")
-            price = item.get("price")
+            # Pull the price from the json. Some results use a nested
+            # `units` list while others expose `unformattedPrice` or
+            # `price`. We try all options so that the value is populated.
+            price = (
+                item.get("price")
+                or item.get("unformattedPrice")
+                or (item.get("units") or [{}])[0].get("price")
+            )
             link = item.get("detailUrl")
             if link and link.startswith("/"):
                 link = f"https://www.zillow.com{link}"

--- a/static/style.css
+++ b/static/style.css
@@ -55,6 +55,14 @@ table {
     margin-top: 20px;
 }
 
+tbody tr:nth-child(even) {
+    background-color: #f8f8f8;
+}
+
+th {
+    text-align: left;
+}
+
 thead {
     background-color: #007BFF;
     color: white;

--- a/templates/index.html
+++ b/templates/index.html
@@ -14,8 +14,14 @@
             {% for listing in listings %}
                 <tr>
                     <td>{{ listing.address }}</td>
-                    <td>{{ listing.price }}</td>
-                    <td><a href="{{ listing.link }}" target="_blank">View</a></td>
+                    <td>{{ listing.price or 'N/A' }}</td>
+                    <td>
+                        {% if listing.link %}
+                        <a href="{{ listing.link }}" target="_blank">View</a>
+                        {% else %}
+                        N/A
+                        {% endif %}
+                    </td>
                 </tr>
             {% endfor %}
             </tbody>


### PR DESCRIPTION
## Summary
- ensure prices are extracted from multiple JSON fields
- show fallback text when a listing has missing data
- improve table styling for readability

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python - <<'PY'
from app import scrape_listings
try:
    data = scrape_listings()
    print('entries', len(data))
except Exception as e:
    print('err', e)
PY`

------
https://chatgpt.com/codex/tasks/task_e_6859b29dfebc832698082eaa5dbcb6ca